### PR TITLE
Makefile: Use CC variable instead of hardcoding 'cc'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(DEPFILES):
 include $(wildcard $(DEPFILES))
 
 $(TARGET): $(OBJS)
-	cc -o $(TARGET) $(OBJS) ${LDFLAGS}
+	$(CC) -o $(TARGET) $(OBJS) ${LDFLAGS}
 
 ifeq ($(PREFIX),)
   PREFIX := /usr/local


### PR DESCRIPTION
When [packaging this for](https://git.rekahsoft.ca/rekahsoft/rekahsoft-guix/compare/bc3be7c43998d0f91095f4bfcd07c2497d81935e...master) [Guix](https://guix.gnu.org/), I found `cc` was being used directly (and worked around it), but it seems this was not intended (given there is already a CC variable).